### PR TITLE
accept client start time of 0

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -272,7 +272,7 @@ Client.prototype.queries = function() {
 * @returns {String} request URL.
 */
 Client.prototype.url = function() {
-	if ( !this._start ) {
+	if ( !this._start && this._start !== 0 ) {
 		throw new Error( 'url()::not initialized. Must first specify a query start time.' );
 	}
 	if ( !this._queries || !this._queries.length ) {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   ],
   "dependencies": {
     "opentsdb-url": "0.0.1",
-    "opentsdb-validate-time": "0.0.1",
+    "opentsdb-validate-time": "^0.0.1",
     "request": "^2.45.0"
   },
   "peerDependencies": {

--- a/test/test.js
+++ b/test/test.js
@@ -549,6 +549,23 @@ describe( 'opentsdb-client', function tests() {
 				client.url();
 			}
 		});
+		
+		it( 'should return a URL string when start = 0', function test() {
+			var query = mQuery();
+
+			query.metric( 'cpu.utilization' );
+			try {
+				
+				client.start( 0 );
+			} catch(e) {
+				console.log(e)
+			}
+			
+			client.queries( query )
+				.start( Date.now() );
+				
+			expect( client.url() ).to.be.a( 'string' );
+		});
 
 		it( 'should return a URL string', function test() {
 			var query = mQuery();


### PR DESCRIPTION
It's useful for users to be able to query opentsdb from unix time `0`. This PR allows for this.
