### PR TITLE
allow ignoring host validation to be IP or localhost

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -88,14 +88,20 @@ function Client() {
 * @param {String} [url] - host URL
 * @returns {Client|String} Client instance or host URL
 */
-Client.prototype.host = function( url ) {
+Client.prototype.host = function( url, options ) {
 	if ( !arguments.length ) {
 		return this._host;
 	}
 	if ( typeof url !== 'string' ) {
 		throw new TypeError( 'host()::invalid input argument. URL must be a string.' );
 	}
-	if ( !IP.test( url ) ) {
+        if ( !options ) {
+           options = {};
+        }
+        if ( options.validate == null ) {
+           options.validate = true;
+        }
+	if ( options.validate && !IP.test( url ) ) {
 		throw new Error( 'host()::invalid input argument. URL is not valid. Ensure valid IP or `localhost`.' );
 	}
 	this._host = url;

--- a/test/test.js
+++ b/test/test.js
@@ -86,7 +86,7 @@ describe( 'opentsdb-client', function tests() {
 			}
 		});
 
-		it( 'should not allow an invalid host', function test() {
+		it( 'should not allow an invalid host by default', function test() {
 			var values = [
 					'badhost',
 					'1000.10.10.100'
@@ -99,6 +99,25 @@ describe( 'opentsdb-client', function tests() {
 			function badValue( value ) {
 				return function() {
 					client.host( value );
+				};
+			}
+		});
+
+		it( 'should skip host validation if explicitly asked by client', function test() {
+			var values = [
+					'badhost',
+					'1000.10.10.100'
+				];
+
+			for ( var i = 0; i < values.length; i++ ) {
+				setHost( values[i], { validate: false } )();
+				assert.strictEqual(client.host(), values[i]);
+				expect( setHost( values[i], { validate: true } ) ).to.throw( Error );
+			}
+
+			function setHost( value, options ) {
+				return function() {
+					client.host( value, options );
 				};
 			}
 		});


### PR DESCRIPTION
fixes #2

instead of trying to verify/parse all the possible
available domain name formats (which now include more
than just ascii chars), this approach allows the calling
client to explicitly disable host/ip verification.

This change is backwards compatible, relying on a new, optional
argument.